### PR TITLE
Np 1387 update roles when user is updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,11 @@ plugins {
 allprojects {
     apply plugin: 'nebula.lint'
 
-//    gradleLint {
-//        //TODO: fix gradle linting after refactor
-//        //rules = ['all-dependency', 'duplicate-dependency-class', 'unused-exclude-by-dep']
-//        rules = ['unused-dependency']
-//    }
+    gradleLint {
+        //TODO: fix gradle linting after refactor
+        //rules = ['all-dependency', 'duplicate-dependency-class', 'unused-exclude-by-dep']
+        rules = ['unused-dependency']
+    }
 
     repositories {
         jcenter()

--- a/user-access-commons/src/main/java/no/unit/nva/database/DatabaseServiceImpl.java
+++ b/user-access-commons/src/main/java/no/unit/nva/database/DatabaseServiceImpl.java
@@ -201,7 +201,7 @@ public class DatabaseServiceImpl implements DatabaseService {
 
     private static RuntimeException logErrorWithDynamoClientAndThrowException(Failure<AmazonDynamoDB> failure) {
         logger.error(DYNAMO_DB_CLIENT_NOT_SET_ERROR);
-        throw new RuntimeException(failure.getException());
+        return new RuntimeException(failure.getException());
     }
 
     private boolean userHasChanged(UserDto existingUser, UserDb desiredUpdateWithSyncedRoles)

--- a/user-access-commons/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
+++ b/user-access-commons/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
@@ -148,7 +148,7 @@ public class DatabaseServiceTest extends DatabaseAccessor {
     @Test
     public void addUserSavesAUserWithoutInstitution() throws InvalidEntryInternalException, ConflictException,
                                                              InvalidInputException, NotFoundException {
-        UserDto expectedUser = createSampleUserAndAddUserToDb(SOME_USERNAME,null, SOME_ROLE);
+        UserDto expectedUser = createSampleUserAndAddUserToDb(SOME_USERNAME, null, SOME_ROLE);
         UserDto actualUser = db.getUser(expectedUser);
 
         assertThat(actualUser, is(equalTo(expectedUser)));
@@ -274,14 +274,27 @@ public class DatabaseServiceTest extends DatabaseAccessor {
 
     private UserDto cloneAndChangeRole(UserDto existingUser) throws InvalidEntryInternalException {
         RoleDto someOtherRole = createRole(SOME_OTHER_ROLE);
+        addRoleToDb(someOtherRole);
         return existingUser.copy().withRoles(Collections.singletonList(someOtherRole)).build();
     }
 
     private UserDto createSampleUserAndAddUserToDb(String username, String institution, String roleName)
         throws InvalidEntryInternalException, ConflictException, InvalidInputException {
         UserDto userDto = createSampleUser(username, institution, roleName);
+        List<RoleDto> roles = userDto.getRoles();
+        roles.stream().forEach(this::addRoleToDb);
         db.addUser(userDto);
         return userDto;
+    }
+
+    private void addRoleToDb(RoleDto role) {
+        try {
+            db.addRole(role);
+        } catch (InvalidInputException | InvalidEntryInternalException e) {
+            throw new RuntimeException(e);
+        } catch (ConflictException e) {
+            System.out.println("Role exists:" + role.toString());
+        }
     }
 
     private UserDto createSampleUser(String username, String institution, String roleName)

--- a/user-access-commons/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
+++ b/user-access-commons/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
@@ -4,6 +4,7 @@ import static java.util.Objects.nonNull;
 import static no.unit.nva.database.DatabaseServiceImpl.DYNAMO_DB_CLIENT_NOT_SET_ERROR;
 import static no.unit.nva.database.DatabaseServiceImpl.createTable;
 import static no.unit.nva.model.DoesNotHaveNullFields.doesNotHaveNullFields;
+import static no.unit.nva.utils.EntityUtils.SOME_ROLENAME;
 import static no.unit.nva.utils.EntityUtils.createRole;
 import static no.unit.nva.utils.EntityUtils.createUserWithoutUsername;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.function.Executable;
 
 public class DatabaseServiceTest extends DatabaseAccessor {
 
+    public static final String SOME_GIVEN_NAME1 = "SomeGivenName";
     private static final String SOME_USERNAME = "someusername";
     private static final String SOME_OTHER_USERNAME = "someotherusername";
     private static final String SOME_GIVEN_NAME = "givenName";
@@ -182,14 +184,30 @@ public class DatabaseServiceTest extends DatabaseAccessor {
         String conflictingUsername = SOME_USERNAME;
         createSampleUserAndAddUserToDb(conflictingUsername, SOME_INSTITUTION, SOME_ROLE);
 
-        UserDto conflictingUser = UserDto.newBuilder().withUsername(conflictingUsername)
-            .withInstitution(SOME_OTHER_INSTITUTION)
-            .withRoles(Collections.singletonList(createRole(SOME_OTHER_ROLE)))
-            .build();
+        UserDto conflictingUser = createUserWithRole(conflictingUsername,
+            SOME_OTHER_INSTITUTION, createRole(SOME_OTHER_ROLE));
 
         Executable action = () -> db.addUser(conflictingUser);
         ConflictException exception = assertThrows(ConflictException.class, action);
         assertThat(exception.getMessage(), containsString(DatabaseServiceImpl.USER_ALREADY_EXISTS_ERROR_MESSAGE));
+    }
+
+    @DisplayName("updateUser() updates existing user with input user when input user is valid")
+    @Test
+    public void updateUserUpdatesAssignsCorrectVersionOfRoleinUser()
+        throws ConflictException, InvalidEntryInternalException, NotFoundException, InvalidInputException {
+        RoleDto existingRole = createRole(SOME_ROLE);
+        db.addRole(existingRole);
+        UserDto existingUser = createUserWithRole(SOME_USERNAME, SOME_INSTITUTION, existingRole);
+        db.addUser(existingUser);
+
+        UserDto userUpdate = userUpdateWithRoleMissingAccessRights(existingUser);
+
+        UserDto expectedUser = existingUser.copy().withGivenName(SOME_GIVEN_NAME).build();
+        db.updateUser(userUpdate);
+        UserDto actualUser = db.getUser(expectedUser);
+        assertThat(actualUser, is(equalTo(expectedUser)));
+        assertThat(actualUser, is(not(sameInstance(expectedUser))));
     }
 
     @DisplayName("updateUser() updates existing user with input user when input user is valid")
@@ -217,7 +235,7 @@ public class DatabaseServiceTest extends DatabaseAccessor {
 
     @DisplayName("updateUser() throws InvalidInputException when the input is invalid ")
     @Test
-    public void updateUserThrowsInvalidInputExceptionWhenTheInputisInvalid()
+    public void updateUserThrowsInvalidInputExceptionWhenTheInputIsInvalid()
         throws ConflictException, InvalidEntryInternalException, InvalidInputException, NoSuchMethodException,
                IllegalAccessException, InvocationTargetException {
         createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLE);
@@ -259,6 +277,24 @@ public class DatabaseServiceTest extends DatabaseAccessor {
             () -> createTable(null, mockEnvironment());
         assertThrows(RuntimeException.class, action);
         assertThat(appender.getMessages(), containsString(DYNAMO_DB_CLIENT_NOT_SET_ERROR));
+    }
+
+    private UserDto userUpdateWithRoleMissingAccessRights(UserDto existingUser)
+        throws InvalidEntryInternalException {
+        RoleDto roleWithOnlyRolename = RoleDto.newBuilder().withName(SOME_ROLENAME).build();
+        UserDto userUpdate = existingUser.copy()
+            .withGivenName(SOME_GIVEN_NAME)
+            .withRoles(Collections.singletonList(roleWithOnlyRolename))
+            .build();
+        return userUpdate;
+    }
+
+    private UserDto createUserWithRole(String someUsername, String someInstitution, RoleDto existingRole)
+        throws InvalidEntryInternalException {
+        return UserDto.newBuilder().withUsername(someUsername)
+            .withInstitution(someInstitution)
+            .withRoles(Collections.singletonList(existingRole))
+            .build();
     }
 
     private UserDto createSampleUserWithoutInstitutionOrRoles(String username)

--- a/user-access-handlers/src/test/java/features/RoleFt.java
+++ b/user-access-handlers/src/test/java/features/RoleFt.java
@@ -31,7 +31,7 @@ public class RoleFt extends ScenarioTest {
         super(scenarioContext);
     }
 
-    @Given("^an (\\w*) with role-name \"(\\w*)\" that exists in the Database$")
+    @Given("^an{0,1} (\\w*) with role-name \"(\\w*)\" that exists in the Database$")
     public void an_ExistingRole_with_role_name(String roleAlias, String roleName)
         throws ConflictException, InvalidEntryInternalException, InvalidInputException {
         RoleDto roleDto = addRoleToExampleRoles(roleAlias, roleName);

--- a/user-access-handlers/src/test/resources/features/Users.feature
+++ b/user-access-handlers/src/test/resources/features/Users.feature
@@ -5,6 +5,7 @@ Feature: Users
 
     Given a Database for users and roles
     And an AuthorizedClient that is authorized through Feide
+    And an ExistingRole with role-name "RoleA" that exists in the Database
 
     And an ExistingUser with username "existingUser" that exists in the Database
     And the ExistingUser belongs to the institution "StandardInstitution"
@@ -33,6 +34,7 @@ Feature: Users
     Then a NotFound message is returned
 
   Scenario:  Authorized client updates existing user
+    Given a NewRole with role-name "roleAfterUpdate" that exists in the Database
     When the AuthorizedClient requests to update the ExistingUser setting the following roles:
       | roles           |
       | roleAfterUpdate |


### PR DESCRIPTION
When a User entry is updated, the roles are read from the Dynamo table and the newest versions are added to the user. 
This means 
 A)
that the when a user is updated to acquire a new role, the update does not have to specify all the access rights of the role that is assigned to the user.

B) 
A role update will can be treated by the users initiating an update with no changes.

C)
The access rights of a user are actually controlled by the roles stored in the database and not by the "role" object that is pushed during the user update.
