### PR TITLE
Np 1387 remove dependency of internal model from public model (Depends on previous PR)

### DIFF
--- a/user-access-handlers/build.gradle
+++ b/user-access-handlers/build.gradle
@@ -2,9 +2,10 @@ dependencies {
 
     implementation project(':user-access-commons')
     implementation project(':user-access-public-model')
-    implementation project(':user-access-internal-model')
+
     implementation project(':user-access-errors')
     implementation project(':user-access-service')
+
 
     implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
 
@@ -14,6 +15,7 @@ dependencies {
 
 
     testImplementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
+    testImplementation project(':user-access-internal-model')
     testImplementation project(':user-access-testing')
 
 }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/EntityUtils.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/EntityUtils.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Set;
 import no.unit.nva.testutils.HandlerRequestBuilder;
-import no.unit.nva.useraccessmanagement.dao.AccessRight;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessmanagement.model.RoleDto;
 import no.unit.nva.useraccessmanagement.model.UserDto;
@@ -19,8 +18,8 @@ public final class EntityUtils {
     public static final String SOME_ROLENAME = "SomeRole";
     public static final String SOME_INSTITUTION = "SomeInstitution";
     public static final String EMPTY_STRING = "";
-    public static final Set<AccessRight> SAMPLE_ACCESS_RIGHTS =
-        Collections.singleton(AccessRight.APPROVE_DOI_REQUEST);
+    public static final Set<String> SAMPLE_ACCESS_RIGHTS =
+        Collections.singleton("APPROVE_DOI_REQUEST");
     private static final String SOME_GIVEN_NAME = "givenName";
     private static final String SOME_FAMILY_NAME = "familyName";
 

--- a/user-access-internal-model/build.gradle
+++ b/user-access-internal-model/build.gradle
@@ -8,6 +8,10 @@ dependencies{
         because("commons is used by all modules in this project")
     }
 
+
+    compileOnly project(":user-access-public-model")
+    testImplementation project(":user-access-public-model")
+
     compileOnly project(":user-access-commons")
     testImplementation project(":user-access-commons")
 

--- a/user-access-internal-model/src/main/java/no/unit/nva/useraccessmanagement/dao/AccessRight.java
+++ b/user-access-internal-model/src/main/java/no/unit/nva/useraccessmanagement/dao/AccessRight.java
@@ -24,9 +24,9 @@ public enum AccessRight {
     @JsonCreator
     public static AccessRight fromString(String accessRight) {
 
-        String lowerCased = accessRight.toLowerCase(Locale.getDefault());
-        if (index.containsKey(lowerCased)) {
-            return index.get(lowerCased);
+        String formattedString = formatString(accessRight);
+        if (index.containsKey(formattedString)) {
+            return index.get(formattedString);
         } else {
             throw new InvalidAccessRightException(accessRight);
         }
@@ -35,7 +35,11 @@ public enum AccessRight {
     @Override
     @JsonValue
     public String toString() {
-        return this.name().toLowerCase(Locale.getDefault());
+        return formatString(this.name());
+    }
+
+    private static String formatString(String accessRightString) {
+        return accessRightString.toUpperCase(Locale.getDefault());
     }
 
     private static Map<String, AccessRight> createIndex() {

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/AccessRightTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/AccessRightTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.function.Executable;
 
 class AccessRightTest {
 
-    public static final String APPROVE_DOI_REQUEST_STRING = "\"approve_doi_request\"";
+    public static final String APPROVE_DOI_REQUEST_STRING = "\"APPROVE_DOI_REQUEST\"";
 
     @Test
     public void fromStringParsesStringCaseInsensitive() {
@@ -31,7 +31,7 @@ class AccessRightTest {
     }
 
     @Test
-    public void accessRightIsSerializedLowerCased() throws JsonProcessingException {
+    public void accessRightIsSerializedUpperCase() throws JsonProcessingException {
         String value = JsonUtils.objectMapper.writeValueAsString(AccessRight.APPROVE_DOI_REQUEST);
         String expectedValue = APPROVE_DOI_REQUEST_STRING;
         assertThat(value, is(equalTo(expectedValue)));

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/EntityUtils.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/EntityUtils.java
@@ -1,11 +1,15 @@
-package no.unit.nva.database;
+package no.unit.nva.useraccessmanagement.dao;
 
+import static no.unit.nva.useraccessmanagement.dao.AccessRight.APPROVE_DOI_REQUEST;
+import static nva.commons.utils.JsonUtils.objectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
-import no.unit.nva.useraccessmanagement.dao.AccessRight;
+import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessmanagement.model.RoleDto;
 import no.unit.nva.useraccessmanagement.model.UserDto;
@@ -17,9 +21,47 @@ public final class EntityUtils {
     public static final String SOME_INSTITUTION = "SomeInstitution";
     public static final String EMPTY_STRING = "";
     public static final Set<AccessRight> SAMPLE_ACCESS_RIGHTS =
-        Collections.singleton(AccessRight.APPROVE_DOI_REQUEST);
+        Collections.singleton(APPROVE_DOI_REQUEST);
     private static final String SOME_GIVEN_NAME = "givenName";
     private static final String SOME_FAMILY_NAME = "familyName";
+
+    /**
+     * Creates a request for adding a user without a username. To be used with {@code handleRequest()} method.
+     *
+     * @return an RequestBuilder that can produce an {@link InputStream} that contains a request to be processed by a
+     *     {@link com.amazonaws.services.lambda.runtime.RequestStreamHandler}.
+     * @throws JsonProcessingException       if JSON serialization fails.
+     * @throws InvalidEntryInternalException unlikely. The object is intentionally invalid.
+     * @throws InvalidEntryInternalException when role is invalid.
+     * @throws NoSuchMethodException         reflection related.
+     * @throws IllegalAccessException        reflection related.
+     * @throws InvocationTargetException     reflection related.
+     */
+    public static HandlerRequestBuilder<UserDto> createRequestBuilderWithUserWithoutUsername()
+        throws JsonProcessingException, InvalidEntryInternalException,
+               NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        UserDto userWithoutUsername = createUserWithoutUsername();
+        return new HandlerRequestBuilder<UserDto>(objectMapper)
+            .withBody(userWithoutUsername);
+    }
+
+    /**
+     * Creates a request for adding a user without a username. To be used with {@code handleRequest()} method.
+     *
+     * @return an InputStream containing the ApiGateway request to be handled by a {@link
+     *     com.amazonaws.services.lambda.runtime.RequestStreamHandler}.
+     * @throws JsonProcessingException       if JSON serialization fails.
+     * @throws InvalidEntryInternalException unlikely. The object is intentionally invalid.
+     * @throws InvalidEntryInternalException when role is invalid.
+     * @throws NoSuchMethodException         reflection related.
+     * @throws IllegalAccessException        reflection related.
+     * @throws InvocationTargetException     reflection related.
+     */
+    public static InputStream createRequestWithUserWithoutUsername()
+        throws JsonProcessingException, InvalidEntryInternalException,
+               NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        return createRequestBuilderWithUserWithoutUsername().build();
+    }
 
     /**
      * Creates a user without a username. For testing output on invalid input.
@@ -40,6 +82,16 @@ public final class EntityUtils {
         method.invoke(userWithoutUsername, EMPTY_STRING);
 
         return userWithoutUsername;
+    }
+
+    /**
+     * create user without roles.
+     *
+     * @return {@link UserDto}
+     * @throws InvalidEntryInternalException When the user is invalid. The user is supposed to be a valid user
+     */
+    public static UserDto createUserWithoutRoles() throws InvalidEntryInternalException {
+        return UserDto.newBuilder().withUsername(SOME_USERNAME).build();
     }
 
     /**
@@ -74,19 +126,19 @@ public final class EntityUtils {
     /**
      * Creates a sample role.
      *
-     * @param someRole the role.
-     * @return the role.
-     * @throws InvalidEntryInternalException when generated role is invalid.
+     * @param someRole the role name.
+     * @return the sample role.
+     * @throws InvalidEntryInternalException when the generated role is invalid
      */
     public static RoleDto createRole(String someRole) throws InvalidEntryInternalException {
-        Set<String> sampleAccessRights = SAMPLE_ACCESS_RIGHTS
+        Set<String> accessRights = SAMPLE_ACCESS_RIGHTS
             .stream()
             .map(AccessRight::toString)
             .collect(Collectors.toSet());
         return
             RoleDto.newBuilder()
                 .withName(someRole)
-                .withAccessRights(sampleAccessRights)
+                .withAccessRights(accessRights)
                 .build();
     }
 }

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/UserDbTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/UserDbTest.java
@@ -1,5 +1,7 @@
 package no.unit.nva.useraccessmanagement.dao;
 
+import static no.unit.nva.useraccessmanagement.dao.EntityUtils.createUserWithRolesAndInstitution;
+import static no.unit.nva.useraccessmanagement.dao.UserDb.ERROR_DUE_TO_INVALID_ROLE;
 import static nva.commons.utils.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -7,15 +9,23 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.useraccessmanagement.dao.UserDb.Builder;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
+import no.unit.nva.useraccessmanagement.model.RoleDto;
+import no.unit.nva.useraccessmanagement.model.UserDto;
 import nva.commons.utils.attempt.Try;
+import nva.commons.utils.log.LogUtils;
+import nva.commons.utils.log.TestAppender;
+import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -25,6 +35,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 public class UserDbTest {
 
     public static final String SOME_USERNAME = "someUser";
+    public static final String SOME_ROLENAME = "someRole";
     public static final String SOME_GIVEN_NAME = "givenName";
     public static final String SOME_FAMILY_NAME = "familyName";
     public static final String SOME_INSTITUTION = "SomeInstitution";
@@ -44,6 +55,13 @@ public class UserDbTest {
         sampleUser.setPrimaryHashKey("SomeOtherHashKey");
         String expectedHashKey = String.join(UserDb.FIELD_DELIMITER, UserDb.TYPE, SOME_USERNAME);
         assertThat(sampleUser.getPrimaryHashKey(), is(equalTo(expectedHashKey)));
+    }
+
+    @Test
+    public void extractRolesDoesNotThrowExceptionWhenRolesAreValid() throws InvalidEntryInternalException {
+        UserDb userWithValidRole = UserDb.fromUserDto(createUserWithRolesAndInstitution());
+        Executable action = userWithValidRole::toUserDto;
+        assertDoesNotThrow(action);
     }
 
     @Test
@@ -72,7 +90,7 @@ public class UserDbTest {
     }
 
     @Test
-    void setTypeShouldNotChangeTheReturnedTypeValue() throws InvalidEntryInternalException {
+    void setTypeShouldNotChangeTheReturnedTypeValue() {
         dynamoFunctionalityTestUser.setType("NotExpectedType");
         assertThat(dynamoFunctionalityTestUser.getType(), is(equalTo(UserDb.TYPE)));
     }
@@ -122,6 +140,57 @@ public class UserDbTest {
         assertThat(exception.getMessage(), containsString(UserDb.INVALID_PRIMARY_HASH_KEY));
     }
 
+    @ParameterizedTest(name = "fromUserDb throws Exception user contains invalidRole. Rolename:\"{0}\"")
+    @NullAndEmptySource
+    void fromUserDbThrowsExceptionWhenUserDbContainsInvalidRole(String invalidRoleName)
+        throws InvalidEntryInternalException {
+        RoleDb invalidRole = new RoleDb();
+        invalidRole.setName(invalidRoleName);
+        List<RoleDb> invalidRoles = Collections.singletonList(invalidRole);
+        UserDb userDbWithInvalidRole = UserDb.newBuilder().withUsername(SOME_USERNAME).withRoles(invalidRoles).build();
+
+        Executable action = userDbWithInvalidRole::toUserDto;
+        RuntimeException exception = assertThrows(RuntimeException.class, action);
+        assertThat(exception.getCause(), is(instanceOf(InvalidEntryInternalException.class)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void toUserDbThrowsExceptionWhenUserDbContainsInvalidRole(String invalidRoleName)
+        throws InvalidEntryInternalException {
+        RoleDto invalidRole = RoleDto.newBuilder().withName(SOME_ROLENAME).build();
+        invalidRole.setRoleName(invalidRoleName);
+        List<RoleDto> invalidRoles = Collections.singletonList(invalidRole);
+        UserDto userWithInvalidRole = UserDto.newBuilder().withUsername(SOME_USERNAME).withRoles(invalidRoles).build();
+
+        Executable action = () -> UserDb.fromUserDto(userWithInvalidRole);
+        RuntimeException exception = assertThrows(RuntimeException.class, action);
+        assertThat(exception.getCause(), is(instanceOf(InvalidEntryInternalException.class)));
+    }
+
+    @Test
+    void roleValidationMethodLogsError()
+        throws InvalidEntryInternalException {
+        TestAppender appender = LogUtils.getTestingAppender(UserDb.class);
+        RoleDto invalidRole = RoleDto.newBuilder().withName(SOME_ROLENAME).build();
+        invalidRole.setRoleName(null);
+
+        List<RoleDto> invalidRoles = Collections.singletonList(invalidRole);
+        UserDto userWithInvalidRole = UserDto.newBuilder().withUsername(SOME_USERNAME).withRoles(invalidRoles).build();
+
+        Executable action = () -> UserDb.fromUserDto(userWithInvalidRole);
+        assertThrows(RuntimeException.class, action);
+
+        assertThat(appender.getMessages(), StringContains.containsString(ERROR_DUE_TO_INVALID_ROLE));
+    }
+
+    @Test
+    void toUserDbReturnsValidUserDbWhenUserDtoIsValid() throws InvalidEntryInternalException {
+        UserDto userOnlyWithOnlyUsername = UserDto.newBuilder().withUsername(SOME_USERNAME).build();
+        UserDto actualUserOnlyWithName = convertToUserDbAndBack(userOnlyWithOnlyUsername);
+        assertThat(actualUserOnlyWithName, is(equalTo(userOnlyWithOnlyUsername)));
+    }
+
     private static List<RoleDb> createSampleRoles() {
         return Stream.of("Role1", "Role2")
             .map(attempt(UserDbTest::newRole))
@@ -131,5 +200,9 @@ public class UserDbTest {
 
     private static RoleDb newRole(String str) throws InvalidEntryInternalException {
         return RoleDb.newBuilder().withName(str).build();
+    }
+
+    private UserDto convertToUserDbAndBack(UserDto userDto) throws InvalidEntryInternalException {
+        return UserDb.fromUserDto(userDto).toUserDto();
     }
 }

--- a/user-access-public-model/build.gradle
+++ b/user-access-public-model/build.gradle
@@ -1,17 +1,14 @@
-dependencies{
+dependencies {
 
     compileOnly group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
     testImplementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
 
-    compileOnly project(":user-access-internal-model")
-    testImplementation project(":user-access-internal-model")
 
     compileOnly project(":user-access-errors")
     testImplementation project(":user-access-errors")
 
     compileOnly project(":user-access-commons")
     testImplementation project(":user-access-commons")
-
 
 
 }

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessmanagement/model/RoleDto.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessmanagement/model/RoleDto.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import no.unit.nva.useraccessmanagement.dao.AccessRight;
-import no.unit.nva.useraccessmanagement.dao.RoleDb;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
 import no.unit.nva.useraccessmanagement.interfaces.JsonSerializable;
@@ -17,7 +15,6 @@ import no.unit.nva.useraccessmanagement.model.interfaces.Typed;
 import no.unit.nva.useraccessmanagement.model.interfaces.Validable;
 import nva.commons.utils.JacocoGenerated;
 import nva.commons.utils.JsonUtils;
-import nva.commons.utils.attempt.Try;
 
 @JsonTypeName(RoleDto.TYPE)
 public class RoleDto implements WithCopy<Builder>, JsonSerializable, Validable, Typed {
@@ -27,7 +24,7 @@ public class RoleDto implements WithCopy<Builder>, JsonSerializable, Validable, 
     @JsonProperty("rolename")
     private String roleName;
     @JsonProperty("accessRights")
-    private Set<AccessRight> accessRights;
+    private Set<String> accessRights;
 
     public RoleDto() {
         accessRights = Collections.emptySet();
@@ -46,21 +43,6 @@ public class RoleDto implements WithCopy<Builder>, JsonSerializable, Validable, 
         return new Builder();
     }
 
-    /**
-     * Creates a DTO from a DAO.
-     *
-     * @param roleDb the DAO
-     * @return the DTO
-     * @throws InvalidEntryInternalException when the input is not valid.
-     */
-    public static RoleDto fromRoleDb(RoleDb roleDb) throws InvalidEntryInternalException {
-        return Try.attempt(() -> newBuilder()
-            .withName(roleDb.getName())
-            .withAccessRights(roleDb.getAccessRights())
-            .build())
-            .orElseThrow(fail -> new InvalidEntryInternalException(fail.getException()));
-    }
-
     @Override
     public Builder copy() {
         return new Builder()
@@ -77,16 +59,12 @@ public class RoleDto implements WithCopy<Builder>, JsonSerializable, Validable, 
         this.roleName = roleName;
     }
 
-    public Set<AccessRight> getAccessRights() {
+    public Set<String> getAccessRights() {
         return accessRights;
     }
 
-    public void setAccessRights(Set<AccessRight> accessRights) {
+    public void setAccessRights(Set<String> accessRights) {
         this.accessRights = accessRights;
-    }
-
-    public RoleDb toRoleDb() throws InvalidEntryInternalException {
-        return RoleDb.newBuilder().withName(this.roleName).withAccessRights(accessRights).build();
     }
 
     @Override
@@ -128,7 +106,7 @@ public class RoleDto implements WithCopy<Builder>, JsonSerializable, Validable, 
     public static final class Builder {
 
         private String roleName;
-        private Set<AccessRight> accessRights;
+        private Set<String> accessRights;
 
         private Builder() {
             this.accessRights = Collections.emptySet();
@@ -139,7 +117,7 @@ public class RoleDto implements WithCopy<Builder>, JsonSerializable, Validable, 
             return this;
         }
 
-        public Builder withAccessRights(Set<AccessRight> accessRights) {
+        public Builder withAccessRights(Set<String> accessRights) {
             this.accessRights = accessRights;
             return this;
         }

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/EntityUtils.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/EntityUtils.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Set;
 import no.unit.nva.testutils.HandlerRequestBuilder;
-import no.unit.nva.useraccessmanagement.dao.AccessRight;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
 
 public final class EntityUtils {
@@ -17,8 +16,8 @@ public final class EntityUtils {
     public static final String SOME_ROLENAME = "SomeRole";
     public static final String SOME_INSTITUTION = "SomeInstitution";
     public static final String EMPTY_STRING = "";
-    public static final Set<AccessRight> SAMPLE_ACCESS_RIGHTS =
-        Collections.singleton(AccessRight.APPROVE_DOI_REQUEST);
+    public static final Set<String> SAMPLE_ACCESS_RIGHTS =
+        Collections.singleton("APPROVE_DOI_REQUEST");
     private static final String SOME_GIVEN_NAME = "givenName";
     private static final String SOME_FAMILY_NAME = "familyName";
 

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/EntityUtils.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/EntityUtils.java
@@ -122,9 +122,9 @@ public final class EntityUtils {
     /**
      * Creates a sample role.
      *
-     * @param someRole the role name.
-     * @return the sample role.
-     * @throws InvalidEntryInternalException when the generated role is invalid
+     * @param someRole The sample role role name.
+     * @return the sample role
+     * @throws InvalidEntryInternalException when the generated role is invalid.
      */
     public static RoleDto createRole(String someRole) throws InvalidEntryInternalException {
         return

--- a/user-access-service/src/main/java/no/unit/nva/database/RoleService.java
+++ b/user-access-service/src/main/java/no/unit/nva/database/RoleService.java
@@ -47,7 +47,7 @@ public class RoleService extends DatabaseSubService {
     }
 
     /**
-     * Fethes a role from the database.
+     * Fetches a role from the database.
      *
      * @param queryObject the query object containing the rolename.
      * @return the Role that corresponds to the given rolename.

--- a/user-access-service/src/main/java/no/unit/nva/database/RoleService.java
+++ b/user-access-service/src/main/java/no/unit/nva/database/RoleService.java
@@ -43,7 +43,7 @@ public class RoleService extends DatabaseSubService {
 
         validate(roleDto);
         checkRoleDoesNotExist(roleDto);
-        table.putItem(roleDto.toRoleDb().toItem());
+        table.putItem(RoleDb.fromRoleDto(roleDto).toItem());
     }
 
     /**
@@ -86,9 +86,9 @@ public class RoleService extends DatabaseSubService {
 
     private RoleDto attemptFetchRole(RoleDto queryObject) throws InvalidEntryInternalException {
         RoleDb roledb = Try.of(queryObject)
-            .map(RoleDto::toRoleDb)
+            .map(RoleDb::fromRoleDto)
             .map(this::fetchRoleDao)
             .orElseThrow(DatabaseSubService::handleError);
-        return nonNull(roledb) ? RoleDto.fromRoleDb(roledb) : null;
+        return nonNull(roledb) ? roledb.toRoleDto() : null;
     }
 }

--- a/user-access-service/src/main/java/no/unit/nva/database/UserService.java
+++ b/user-access-service/src/main/java/no/unit/nva/database/UserService.java
@@ -168,7 +168,6 @@ public class UserService extends DatabaseSubService {
     }
 
     private void updateTable(UserDb userUpdateWithSyncedRoles) {
-
         table.putItem(userUpdateWithSyncedRoles.toItem());
     }
 


### PR DESCRIPTION
This is necessary so that other services do not have to import the internal model dependency

Changes:

RoleDto::fromRoleDb -->RoleDb::toRoleDto
RoleDto::toRoleDb -->RoleDb::fromRoleDto
UserDto::fromUserDb -->RoleDb::toUserDto
UserDto::fromUserDb -->RoleDb::toUserDto


