### PR TITLE
Np 1387 Add user adds only existing roles in created user

### DIFF
--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/AddUserTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/AddUserTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva.handlers;
 
 import static no.unit.nva.handlers.AddUserHandler.SYNC_ERROR_MESSAGE;
+
 import static no.unit.nva.handlers.EntityUtils.createRequestWithUserWithoutUsername;
 import static no.unit.nva.handlers.EntityUtils.createUserWithRoleWithoutInstitution;
 import static no.unit.nva.handlers.EntityUtils.createUserWithRolesAndInstitution;
@@ -44,13 +45,14 @@ import org.zalando.problem.Problem;
 
 public class AddUserTest extends HandlerTest {
 
+    public static final String EMPTY_INSTITUTION = null;
     private AddUserHandler handler;
     private RequestInfo requestInfo;
     private Context context;
 
     @BeforeEach
     public void init() {
-        DatabaseServiceImpl databaseService = createDatabaseServiceUsingLocalStorage();
+        databaseService = createDatabaseServiceUsingLocalStorage();
         handler = new AddUserHandler(mockEnvironment(), databaseService);
 
         requestInfo = new RequestInfo();
@@ -76,18 +78,19 @@ public class AddUserTest extends HandlerTest {
     @DisplayName("processInput() adds user to database when input is a user with username and roles")
     @Test
     public void processInputAddsUserToDatabaseWhenInputIsUserWithNamesAndRoles() throws ApiGatewayException {
-        UserDto expectedUser = createUserWithRoleWithoutInstitution();
+        UserDto expectedUser = createSampleUserWithExistingRoles(DEFAULT_USERNAME, EMPTY_INSTITUTION);
         UserDto savedUser = handler.processInput(expectedUser, requestInfo, context);
         assertThat(savedUser, is(not(sameInstance(expectedUser))));
         assertThat(savedUser, is(equalTo(expectedUser)));
     }
 
     @DisplayName("processInput() adds user to database when input is a user with username and roles and with"
-        + "institutions")
+        + " institutions")
     @Test
     public void processInputAddsUserToDatabaseWhenInputIsUserWithNamesAndRolesAndInstitutions()
         throws ApiGatewayException {
-        UserDto expectedUser = createUserWithRolesAndInstitution();
+        UserDto expectedUser = createSampleUserWithExistingRoles();
+
         UserDto savedUser = handler.processInput(expectedUser, requestInfo, context);
         assertThat(savedUser, is(not(sameInstance(expectedUser))));
         assertThat(savedUser, is(equalTo(expectedUser)));

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/AddUserTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/AddUserTest.java
@@ -1,9 +1,7 @@
 package no.unit.nva.handlers;
 
 import static no.unit.nva.handlers.AddUserHandler.SYNC_ERROR_MESSAGE;
-
 import static no.unit.nva.handlers.EntityUtils.createRequestWithUserWithoutUsername;
-import static no.unit.nva.handlers.EntityUtils.createUserWithRoleWithoutInstitution;
 import static no.unit.nva.handlers.EntityUtils.createUserWithRolesAndInstitution;
 import static no.unit.nva.handlers.EntityUtils.createUserWithoutRoles;
 import static no.unit.nva.handlers.EntityUtils.createUserWithoutUsername;
@@ -25,12 +23,10 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import no.unit.nva.database.DatabaseService;
 import no.unit.nva.database.DatabaseServiceImpl;
-
 import no.unit.nva.useraccessmanagement.exceptions.DataSyncException;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
-import no.unit.nva.useraccessmanagement.model.UserDto;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
-
+import no.unit.nva.useraccessmanagement.model.UserDto;
 import nva.commons.exceptions.ApiGatewayException;
 import nva.commons.exceptions.InvalidOrMissingTypeException;
 import nva.commons.exceptions.commonexceptions.ConflictException;

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/GetUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/GetUserHandlerTest.java
@@ -48,7 +48,7 @@ class GetUserHandlerTest extends HandlerTest {
     @DisplayName("handleRequest returns User object with type \"User\"")
     @Test
     public void handleRequestReturnsUserObjectWithTypeRole()
-        throws ConflictException, InvalidEntryInternalException, InvalidInputException, IOException {
+        throws ConflictException, InvalidEntryInternalException, InvalidInputException, IOException, NotFoundException {
         insertSampleUserToDatabase();
 
         ByteArrayOutputStream outputStream = sendGetUserRequestToHandler();

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/HandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/HandlerTest.java
@@ -2,9 +2,6 @@ package no.unit.nva.handlers;
 
 import static nva.commons.utils.JsonUtils.objectMapper;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -20,7 +17,6 @@ import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
 import no.unit.nva.useraccessmanagement.model.RoleDto;
 import no.unit.nva.useraccessmanagement.model.UserDto;
 import nva.commons.exceptions.commonexceptions.ConflictException;
-import nva.commons.exceptions.commonexceptions.NotFoundException;
 
 public class HandlerTest extends DatabaseAccessor {
 
@@ -33,7 +29,7 @@ public class HandlerTest extends DatabaseAccessor {
     protected DatabaseService databaseService;
 
     protected UserDto insertSampleUserToDatabase(String username, String institution)
-        throws InvalidEntryInternalException, ConflictException, InvalidInputException, NotFoundException {
+        throws InvalidEntryInternalException, ConflictException, InvalidInputException {
         UserDto sampleUser = createSampleUserWithExistingRoles(username, institution);
 
         databaseService.addUser(sampleUser);
@@ -41,21 +37,18 @@ public class HandlerTest extends DatabaseAccessor {
     }
 
     protected UserDto insertSampleUserToDatabase()
-        throws InvalidEntryInternalException, ConflictException, InvalidInputException, NotFoundException {
+        throws InvalidEntryInternalException, ConflictException, InvalidInputException {
         return insertSampleUserToDatabase(DEFAULT_USERNAME, DEFAULT_INSTITUTION);
     }
 
     protected UserDto createSampleUserWithExistingRoles(String username, String institution)
-        throws InvalidEntryInternalException, NotFoundException {
+        throws InvalidEntryInternalException {
         UserDto sampleUser = createSampleUser(username, institution);
         sampleUser.getRoles().forEach((this::insertRole));
-        RoleDto role = databaseService.getRole(
-            RoleDto.newBuilder().withName(sampleUser.getRoles().get(0).getRoleName()).build());
-        assertThat(role, is(not(nullValue())));
         return sampleUser;
     }
 
-    protected UserDto createSampleUserWithExistingRoles() throws InvalidEntryInternalException, NotFoundException {
+    protected UserDto createSampleUserWithExistingRoles() throws InvalidEntryInternalException {
         return createSampleUserWithExistingRoles(DEFAULT_USERNAME, DEFAULT_INSTITUTION);
     }
 

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/HandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/HandlerTest.java
@@ -2,8 +2,10 @@ package no.unit.nva.handlers;
 
 import static nva.commons.utils.JsonUtils.objectMapper;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.InputStream;
@@ -12,38 +14,49 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import no.unit.nva.database.DatabaseAccessor;
 import no.unit.nva.database.DatabaseService;
-
+import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
+import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
 import no.unit.nva.useraccessmanagement.model.RoleDto;
 import no.unit.nva.useraccessmanagement.model.UserDto;
-import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
-
-import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.exceptions.commonexceptions.ConflictException;
+import nva.commons.exceptions.commonexceptions.NotFoundException;
 
 public class HandlerTest extends DatabaseAccessor {
 
     public static final String DEFAULT_USERNAME = "someUsername@inst";
     public static final String DEFAULT_ROLE = "SomeRole";
     public static final String DEFAULT_INSTITUTION = "SomeInstitution";
+    public static final String TYPE_ATTRIBUTE = "type";
     private static final String SPECIAL_CHARACTER = "@";
     private static final String ENCODED_SPECIAL_CHARACTER = "%40";
-    public static final String TYPE_ATTRIBUTE = "type";
-
     protected DatabaseService databaseService;
 
     protected UserDto insertSampleUserToDatabase(String username, String institution)
-        throws InvalidEntryInternalException, ConflictException, InvalidInputException {
-        UserDto sampleUser = createSampleUser(username, institution);
+        throws InvalidEntryInternalException, ConflictException, InvalidInputException, NotFoundException {
+        UserDto sampleUser = createSampleUserWithExistingRoles(username, institution);
+
         databaseService.addUser(sampleUser);
         return sampleUser;
     }
 
     protected UserDto insertSampleUserToDatabase()
-        throws InvalidEntryInternalException, ConflictException, InvalidInputException {
-        UserDto sampleUser = createSampleUser(DEFAULT_USERNAME, DEFAULT_INSTITUTION);
-        databaseService.addUser(sampleUser);
+        throws InvalidEntryInternalException, ConflictException, InvalidInputException, NotFoundException {
+        return insertSampleUserToDatabase(DEFAULT_USERNAME, DEFAULT_INSTITUTION);
+    }
+
+    protected UserDto createSampleUserWithExistingRoles(String username, String institution)
+        throws InvalidEntryInternalException, NotFoundException {
+        UserDto sampleUser = createSampleUser(username, institution);
+        sampleUser.getRoles().forEach((this::insertRole));
+        RoleDto role = databaseService.getRole(
+            RoleDto.newBuilder().withName(sampleUser.getRoles().get(0).getRoleName()).build());
+        assertThat(role, is(not(nullValue())));
         return sampleUser;
+    }
+
+    protected UserDto createSampleUserWithExistingRoles() throws InvalidEntryInternalException, NotFoundException {
+        return createSampleUserWithExistingRoles(DEFAULT_USERNAME, DEFAULT_INSTITUTION);
     }
 
     protected UserDto createSampleUser(String username, String institution) throws InvalidEntryInternalException {
@@ -73,5 +86,13 @@ public class HandlerTest extends DatabaseAccessor {
         String output = URLEncoder.encode(inputContainingSpecialCharacter, StandardCharsets.UTF_8);
         assertThat(output, containsString(ENCODED_SPECIAL_CHARACTER));
         return output;
+    }
+
+    private void insertRole(RoleDto role) {
+        try {
+            databaseService.addRole(role);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayOutputStream;
@@ -21,15 +20,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
+import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
+import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
 import no.unit.nva.useraccessmanagement.model.UserDto;
 import no.unit.nva.useraccessmanagement.model.UserList;
-import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
-
-import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.exceptions.commonexceptions.ConflictException;
-import nva.commons.exceptions.commonexceptions.NotFoundException;
 import nva.commons.handlers.GatewayResponse;
 import nva.commons.handlers.RequestInfo;
 import nva.commons.utils.JsonUtils;
@@ -64,7 +60,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
 
     @Test
     public void handleRequestReturnsListOfUsersGivenAnInstitution()
-        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
+        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException {
         UserList expectedUsers = insertTwoUsersOfSameInstitution();
 
         InputStream validRequest = createListRequest(DEFAULT_INSTITUTION);
@@ -79,7 +75,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
 
     @Test
     public void handleRequestReturnsListOfUsersContainingOnlyUsersOfGivenInstitution()
-        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
+        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException {
         UserList insertedUsers = insertTwoUsersOfDifferentInstitutions();
 
         InputStream validRequest = createListRequest(DEFAULT_INSTITUTION);
@@ -98,7 +94,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
 
     @Test
     public void handleRequestReturnsEmptyListOfUsersWhenNoUsersOfSpecifiedInstitutionAreFound()
-        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
+        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException {
         insertTwoUsersOfSameInstitution();
 
         InputStream validRequest = createListRequest(SOME_OTHER_INSTITUTION);
@@ -148,7 +144,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
     }
 
     private UserList insertTwoUsersOfDifferentInstitutions()
-        throws InvalidEntryInternalException, ConflictException, InvalidInputException, NotFoundException {
+        throws InvalidEntryInternalException, ConflictException, InvalidInputException {
         UserList users = new UserList();
         users.add(insertSampleUserToDatabase(DEFAULT_USERNAME, HandlerTest.DEFAULT_INSTITUTION));
         users.add(insertSampleUserToDatabase(SOME_OTHER_USERNAME, SOME_OTHER_INSTITUTION));
@@ -168,7 +164,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
     }
 
     private UserList insertTwoUsersOfSameInstitution()
-        throws ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
+        throws ConflictException, InvalidEntryInternalException, InvalidInputException {
         UserList users = new UserList();
         users.add(insertSampleUserToDatabase(DEFAULT_USERNAME, DEFAULT_INSTITUTION));
         users.add(insertSampleUserToDatabase(SOME_OTHER_USERNAME, DEFAULT_INSTITUTION));

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
@@ -29,6 +29,7 @@ import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
 
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.exceptions.commonexceptions.ConflictException;
+import nva.commons.exceptions.commonexceptions.NotFoundException;
 import nva.commons.handlers.GatewayResponse;
 import nva.commons.handlers.RequestInfo;
 import nva.commons.utils.JsonUtils;
@@ -63,7 +64,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
 
     @Test
     public void handleRequestReturnsListOfUsersGivenAnInstitution()
-        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException {
+        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
         UserList expectedUsers = insertTwoUsersOfSameInstitution();
 
         InputStream validRequest = createListRequest(DEFAULT_INSTITUTION);
@@ -78,7 +79,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
 
     @Test
     public void handleRequestReturnsListOfUsersContainingOnlyUsersOfGivenInstitution()
-        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException {
+        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
         UserList insertedUsers = insertTwoUsersOfDifferentInstitutions();
 
         InputStream validRequest = createListRequest(DEFAULT_INSTITUTION);
@@ -97,7 +98,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
 
     @Test
     public void handleRequestReturnsEmptyListOfUsersWhenNoUsersOfSpecifiedInstitutionAreFound()
-        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException {
+        throws IOException, ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
         insertTwoUsersOfSameInstitution();
 
         InputStream validRequest = createListRequest(SOME_OTHER_INSTITUTION);
@@ -147,7 +148,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
     }
 
     private UserList insertTwoUsersOfDifferentInstitutions()
-        throws InvalidEntryInternalException, ConflictException, InvalidInputException {
+        throws InvalidEntryInternalException, ConflictException, InvalidInputException, NotFoundException {
         UserList users = new UserList();
         users.add(insertSampleUserToDatabase(DEFAULT_USERNAME, HandlerTest.DEFAULT_INSTITUTION));
         users.add(insertSampleUserToDatabase(SOME_OTHER_USERNAME, SOME_OTHER_INSTITUTION));
@@ -167,7 +168,7 @@ class ListByInstitutionHandlerTest extends HandlerTest {
     }
 
     private UserList insertTwoUsersOfSameInstitution()
-        throws ConflictException, InvalidEntryInternalException, InvalidInputException {
+        throws ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
         UserList users = new UserList();
         users.add(insertSampleUserToDatabase(DEFAULT_USERNAME, DEFAULT_INSTITUTION));
         users.add(insertSampleUserToDatabase(SOME_OTHER_USERNAME, DEFAULT_INSTITUTION));

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessmanagement/model/UserDto.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessmanagement/model/UserDto.java
@@ -147,11 +147,13 @@ public class UserDto implements WithCopy<Builder>, JsonSerializable, Validable, 
             return false;
         }
         UserDto userDto = (UserDto) o;
-        return Objects.equals(getUsername(), userDto.getUsername())
+        boolean result1 = Objects.equals(getUsername(), userDto.getUsername())
             && Objects.equals(getGivenName(), userDto.getGivenName())
-            && Objects.equals(getFamilyName(), userDto.getFamilyName())
-            && Objects.equals(getInstitution(), userDto.getInstitution())
-            && Objects.equals(getRoles(), userDto.getRoles());
+            && Objects.equals(getFamilyName(), userDto.getFamilyName());
+        boolean result2 =
+            Objects.equals(getInstitution(), userDto.getInstitution())
+                && Objects.equals(getRoles(), userDto.getRoles());
+        return result1 && result2;
     }
 
     @Override

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessmanagement/model/UserDto.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessmanagement/model/UserDto.java
@@ -147,13 +147,11 @@ public class UserDto implements WithCopy<Builder>, JsonSerializable, Validable, 
             return false;
         }
         UserDto userDto = (UserDto) o;
-        boolean result1 = Objects.equals(getUsername(), userDto.getUsername())
+        return Objects.equals(getUsername(), userDto.getUsername())
             && Objects.equals(getGivenName(), userDto.getGivenName())
-            && Objects.equals(getFamilyName(), userDto.getFamilyName());
-        boolean result2 =
-            Objects.equals(getInstitution(), userDto.getInstitution())
-                && Objects.equals(getRoles(), userDto.getRoles());
-        return result1 && result2;
+            && Objects.equals(getFamilyName(), userDto.getFamilyName())
+            && Objects.equals(getInstitution(), userDto.getInstitution())
+            && Objects.equals(getRoles(), userDto.getRoles());
     }
 
     @Override

--- a/user-access-service/src/main/java/no/unit/nva/database/UserService.java
+++ b/user-access-service/src/main/java/no/unit/nva/database/UserService.java
@@ -89,7 +89,8 @@ public class UserService extends DatabaseSubService {
 
         validate(user);
         checkUserDoesNotAlreadyExist(user);
-        table.putItem(UserDb.fromUserDto(user).toItem());
+        UserDb databaseEntryWithSyncedRoles = syncRoleDetails(UserDb.fromUserDto(user));
+        table.putItem(databaseEntryWithSyncedRoles.toItem());
     }
 
     /**
@@ -107,15 +108,14 @@ public class UserService extends DatabaseSubService {
         logger.debug(UPDATE_USER_DEBUG_MESSAGE + updateObject.toJsonString(objectMapper));
         validate(updateObject);
         UserDto existingUser = getExistingUserOrSendNotFoundError(updateObject);
-        UserDb updatedObjectWithSyncedRoles = checkRoleDetailsAreInSync(updateObject);
+        UserDb updatedObjectWithSyncedRoles = syncRoleDetails(UserDb.fromUserDto(updateObject));
         if (userHasChanged(existingUser, updatedObjectWithSyncedRoles)) {
             updateTable(updatedObjectWithSyncedRoles);
         }
     }
 
-    private UserDb checkRoleDetailsAreInSync(UserDto updateObject) throws InvalidEntryInternalException {
-        UserDb desiredUpdate = UserDb.fromUserDto(updateObject);
-        UserDb desiredUpdateWithSyncedRoles = userWithSyncedRoles(desiredUpdate);
+    private UserDb syncRoleDetails(UserDb updateObject) throws InvalidEntryInternalException {
+        UserDb desiredUpdateWithSyncedRoles = userWithSyncedRoles(updateObject);
         return desiredUpdateWithSyncedRoles;
     }
 

--- a/user-access-service/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
+++ b/user-access-service/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
@@ -16,7 +16,6 @@ import static no.unit.nva.useraccessmanagement.constants.DatabaseIndexDetails.PR
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -233,15 +232,6 @@ public class DatabaseServiceTest extends DatabaseAccessor {
         assertThat(actualUser, is(equalTo(expectedUser)));
     }
 
-    public UserDto createUserWithRoleReference(RoleDto existingRole) throws InvalidEntryInternalException {
-        RoleDto roleWithoutDetails = RoleDto.newBuilder().withName(existingRole.getRoleName()).build();
-        RoleDto.newBuilder().withName(existingRole.getRoleName()).build();
-        return createSampleUser(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME)
-            .copy()
-            .withRoles(Collections.singletonList(roleWithoutDetails))
-            .build();
-    }
-
     @DisplayName("updateUser() updates existing user with input user when input user is valid")
     @Test
     public void updateUserUpdatesAssignsCorrectVersionOfRoleInUser()
@@ -380,6 +370,15 @@ public class DatabaseServiceTest extends DatabaseAccessor {
         } catch (InvalidEntryInternalException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private UserDto createUserWithRoleReference(RoleDto existingRole) throws InvalidEntryInternalException {
+        RoleDto roleWithoutDetails = RoleDto.newBuilder().withName(existingRole.getRoleName()).build();
+        RoleDto.newBuilder().withName(existingRole.getRoleName()).build();
+        return createSampleUser(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME)
+            .copy()
+            .withRoles(Collections.singletonList(roleWithoutDetails))
+            .build();
     }
 
     private Item fetchRoleDirectlyFromTable(Table table, RoleDb roleWithAccessRights) {

--- a/user-access-service/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
+++ b/user-access-service/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
@@ -16,6 +16,7 @@ import static no.unit.nva.useraccessmanagement.constants.DatabaseIndexDetails.PR
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -217,6 +218,19 @@ public class DatabaseServiceTest extends DatabaseAccessor {
         UserDto savedUser = db.getUser(userWithoutRoleDetails);
         RoleDto actualRole = savedUser.getRoles().stream().collect(SingletonCollector.collect());
         assertThat(actualRole, is(equalTo(existingRole)));
+    }
+
+    @Test
+    public void addUserDoesNotAddNonExistingRolesInCreatedUser()
+        throws InvalidEntryInternalException, ConflictException, InvalidInputException, NotFoundException {
+        UserDto userWithNonExistingRole = createUserWithRole(SOME_USERNAME, SOME_INSTITUTION,
+            createRole(SOME_ROLENAME));
+        db.addUser(userWithNonExistingRole);
+
+        UserDto actualUser = db.getUser(userWithNonExistingRole);
+        UserDto expectedUser = userWithNonExistingRole.copy().withRoles(Collections.emptyList()).build();
+
+        assertThat(actualUser, is(equalTo(expectedUser)));
     }
 
     public UserDto createUserWithRoleReference(RoleDto existingRole) throws InvalidEntryInternalException {

--- a/user-access-service/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
+++ b/user-access-service/src/test/java/no/unit/nva/database/DatabaseServiceTest.java
@@ -29,16 +29,17 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import no.unit.nva.useraccessmanagement.dao.AccessRight;
 import no.unit.nva.useraccessmanagement.constants.DatabaseIndexDetails;
+import no.unit.nva.useraccessmanagement.dao.AccessRight;
 import no.unit.nva.useraccessmanagement.dao.RoleDb;
 import no.unit.nva.useraccessmanagement.dao.UserDb;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidEntryInternalException;
+import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
 import no.unit.nva.useraccessmanagement.model.RoleDto;
 import no.unit.nva.useraccessmanagement.model.UserDto;
-import no.unit.nva.useraccessmanagement.exceptions.InvalidInputException;
 import nva.commons.exceptions.commonexceptions.ConflictException;
 import nva.commons.exceptions.commonexceptions.NotFoundException;
+import nva.commons.utils.SingletonCollector;
 import nva.commons.utils.log.LogUtils;
 import nva.commons.utils.log.TestAppender;
 import org.junit.jupiter.api.Assertions;
@@ -205,9 +206,31 @@ public class DatabaseServiceTest extends DatabaseAccessor {
         assertThat(exception.getMessage(), containsString(USER_ALREADY_EXISTS_ERROR_MESSAGE));
     }
 
+    @Test
+    public void addUserAddsCurrentlySavedVersionOfRoleInNewUser()
+        throws ConflictException, InvalidEntryInternalException, InvalidInputException, NotFoundException {
+        RoleDto existingRole = createSampleRoleAndAddToDb(SOME_ROLENAME);
+        assertThat(existingRole, doesNotHaveNullOrEmptyFields());
+
+        UserDto userWithoutRoleDetails = createUserWithRoleReference(existingRole);
+        db.addUser(userWithoutRoleDetails);
+        UserDto savedUser = db.getUser(userWithoutRoleDetails);
+        RoleDto actualRole = savedUser.getRoles().stream().collect(SingletonCollector.collect());
+        assertThat(actualRole, is(equalTo(existingRole)));
+    }
+
+    public UserDto createUserWithRoleReference(RoleDto existingRole) throws InvalidEntryInternalException {
+        RoleDto roleWithoutDetails = RoleDto.newBuilder().withName(existingRole.getRoleName()).build();
+        RoleDto.newBuilder().withName(existingRole.getRoleName()).build();
+        return createSampleUser(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME)
+            .copy()
+            .withRoles(Collections.singletonList(roleWithoutDetails))
+            .build();
+    }
+
     @DisplayName("updateUser() updates existing user with input user when input user is valid")
     @Test
-    public void updateUserUpdatesAssignsCorrectVersionOfRoleinUser()
+    public void updateUserUpdatesAssignsCorrectVersionOfRoleInUser()
         throws ConflictException, InvalidEntryInternalException, NotFoundException, InvalidInputException {
         RoleDto existingRole = createRole(SOME_ROLENAME);
         db.addRole(existingRole);


### PR DESCRIPTION
When adding a new user with some roles, the client does not have to specify the access right of the assigned roles. The service checks the inserted roles and replaces them with the latest version of the roles in the database. This has two effects:

1) A new or updated user will always have the latest version of a role
2) Invalid roles or arbitrary access rights cannot be added to a user