### PR TITLE
NP-1422: fix gradle files according to gradleLint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,4 @@ subprojects {
         archives sourcesJar
     }
 
-
-    task listAllDependencies(type: DependencyReportTask) {}
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
     project.ext{
         nvaCommonsVersion = '0.6.3'
         awsSdkVersion ="1.11.894"
-        jacksonVersion ="2.10.3"
+        jacksonVersion ="2.11.3"
     }
 
     gradleLint {

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ allprojects {
     apply plugin: 'nebula.lint'
 
     project.ext{
-        nvaCommonsVersion = '0.6.0'
+        nvaCommonsVersion = '0.6.3'
         awsSdkVersion ="1.11.894"
-        jacksonVersion ="2.11.3"
+        jacksonVersion ="2.10.3"
     }
 
     gradleLint {
@@ -42,7 +42,14 @@ subprojects {
 
     dependencies {
 
-        testImplementation group: 'com.github.BIBSYSDEV', name: 'nva-testutils', version: '0.1.13'
+        testImplementation (group: 'com.github.BIBSYSDEV', name: 'nva-testutils', version: '0.1.13'){
+            exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+            exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+            exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+            exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+            exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+            exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        }
         testImplementation group: 'com.amazonaws', name: 'DynamoDBLocal', version: '1.12.0'
         testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
 
@@ -130,4 +137,8 @@ subprojects {
     artifacts {
         archives sourcesJar
     }
+
+
+    task listAllDependencies(type: DependencyReportTask) {}
+
 }

--- a/user-access-commons/build.gradle
+++ b/user-access-commons/build.gradle
@@ -1,5 +1,34 @@
 dependencies {
-    implementation( group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion)
+    implementation(group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion) {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-sts'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-secretsmanager'
+        exclude group: 'com.amazonaws', module: 'aws-lambda-java-events'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-lambda'
+    }
+
+    compileOnly(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: project.ext.jacksonVersion) {
+        because "PMD complains"
+    }
+
+    compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.ext.jacksonVersion) {
+        because "PMD complains"
+    }
+    compileOnly(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: project.ext.jacksonVersion) {
+        because "PMD complains"
+    }
+    compileOnly(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: project.ext.jacksonVersion) {
+        because "PMD complains"
+    }
+    compileOnly(group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: project.ext.jacksonVersion) {
+        because "PMD complains"
+    }
+
 
     runtimeOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.ext.jacksonVersion
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.ext.jacksonVersion

--- a/user-access-errors/build.gradle
+++ b/user-access-errors/build.gradle
@@ -1,3 +1,14 @@
 dependencies{
-    implementation( group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion)
+    implementation(group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion) {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-sts'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-secretsmanager'
+        exclude group: 'com.amazonaws', module: 'aws-lambda-java-events'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-lambda'
+    }
 }

--- a/user-access-handlers/build.gradle
+++ b/user-access-handlers/build.gradle
@@ -21,6 +21,10 @@ dependencies {
         because "We use it directly"
     }
 
+    compileOnly(group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion){
+        because "PMD fails without it"
+    }
+
     testImplementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
     testImplementation project(':user-access-internal-model')
     testImplementation project(':user-access-testing')

--- a/user-access-handlers/build.gradle
+++ b/user-access-handlers/build.gradle
@@ -12,7 +12,13 @@ dependencies {
     implementation(group: 'com.amazonaws', name: 'aws-java-sdk-secretsmanager', version: project.ext.awsSdkVersion) {
         because("we need to read the API key")
     }
+    implementation(group: 'org.slf4j', name: 'slf4j-api', version: '1.8.0-beta4') {
+        because "We use it directly"
+    }
 
+    implementation(group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.1') {
+        because "We use it directly"
+    }
 
     testImplementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
     testImplementation project(':user-access-internal-model')

--- a/user-access-internal-model/build.gradle
+++ b/user-access-internal-model/build.gradle
@@ -1,13 +1,40 @@
-dependencies{
+dependencies {
 
     compileOnly(group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion) {
         because("This module contains the Dynamo access details and will be used by " +
                 "any service accessing DynamoDB")
-    }
-    implementation( group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion){
-        because("commons is used by all modules in this project")
+
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+
     }
 
+    implementation (group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion) {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-sts'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-secretsmanager'
+        exclude group: 'com.amazonaws', module: 'aws-lambda-java-events'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-lambda'
+    }
+
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: project.ext.jacksonVersion
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: project.ext.jacksonVersion
+
+    runtimeOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.ext.jacksonVersion
+    runtimeOnly group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: project.ext.jacksonVersion
+    runtimeOnly group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: project.ext.jacksonVersion
+
+
+    testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.ext.jacksonVersion
 
     compileOnly project(":user-access-public-model")
     testImplementation project(":user-access-public-model")
@@ -17,5 +44,6 @@ dependencies{
 
     compileOnly project(":user-access-errors")
     testImplementation project(":user-access-errors")
+
 
 }

--- a/user-access-internal-model/src/test/java/interfaces/JsonSerializableTest.java
+++ b/user-access-internal-model/src/test/java/interfaces/JsonSerializableTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.Objects;
 import no.unit.nva.useraccessmanagement.interfaces.JsonSerializable;
 import nva.commons.utils.JsonUtils;
@@ -22,7 +23,7 @@ class JsonSerializableTest {
     public static final String EXPECTED_ERROR_MESSAGE = "expectedErrorMessage";
 
     @Test
-    public void jsonSerializableReturnsValidJsonString() throws JsonProcessingException {
+    public void jsonSerializableReturnsValidJsonString() throws IOException {
         JsonObject object = sampleObject();
         String json = object.toJsonString();
         JsonObject copy = JsonUtils.objectMapper.readValue(json, JsonObject.class);

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/AccessRightTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessmanagement/dao/AccessRightTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
 import no.unit.nva.useraccessmanagement.exceptions.InvalidAccessRightException;
 import nva.commons.utils.JsonUtils;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ class AccessRightTest {
     }
 
     @Test
-    public void accessRightIsDeserializedFromString() throws JsonProcessingException {
+    public void accessRightIsDeserializedFromString() throws IOException {
         String accessRightString = APPROVE_DOI_REQUEST_STRING;
         AccessRight accessRight = JsonUtils.objectMapper.readValue(accessRightString, AccessRight.class);
         assertThat(accessRight, is(equalTo(AccessRight.APPROVE_DOI_REQUEST)));

--- a/user-access-public-model/build.gradle
+++ b/user-access-public-model/build.gradle
@@ -1,8 +1,39 @@
 dependencies {
 
-    compileOnly group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
-    testImplementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
+    compileOnly(group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion) {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-sts'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-secretsmanager'
+        exclude group: 'com.amazonaws', module: 'aws-lambda-java-events'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-lambda'
+    }
 
+    testImplementation( group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion){
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+    }
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations',version: project.ext.jacksonVersion
+
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core',version: project.ext.jacksonVersion
+    compileOnly group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8',version: project.ext.jacksonVersion
+    compileOnly group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310',version: project.ext.jacksonVersion
+    compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind',version: project.ext.jacksonVersion
+    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names',version: project.ext.jacksonVersion
+
+    runtimeOnly group: 'com.fasterxml.jackson.core', name: 'jackson-core',version: project.ext.jacksonVersion
+    testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core',version: project.ext.jacksonVersion
+    testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind',version: project.ext.jacksonVersion
+    testImplementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310',version: project.ext.jacksonVersion
+    testImplementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8',version: project.ext.jacksonVersion
 
     compileOnly project(":user-access-errors")
     testImplementation project(":user-access-errors")

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/RoleDtoTest.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/RoleDtoTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -125,7 +126,7 @@ public class RoleDtoTest extends DtoTest {
     @DisplayName("RoleDto can be created when it contains the right type value")
     @Test
     public void roleDtoCanBeDeserializedWhenItContainsTheRightTypeValue()
-        throws InvalidEntryInternalException, JsonProcessingException {
+        throws InvalidEntryInternalException, IOException {
         RoleDto someRole = createRole(SOME_ROLE_NAME);
         ObjectNode json = objectMapper.convertValue(someRole, ObjectNode.class);
         assertThatSerializedItemContainsType(json, ROLE_TYPE_LITERAL);

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/UserDtoTest.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessmanagement/model/UserDtoTest.java
@@ -87,7 +87,7 @@ public class UserDtoTest extends DtoTest {
     @DisplayName("UserDto can be created when it contains the right type value")
     @Test
     public void userDtoCanBeDeserializedWhenItContainsTheRightTypeValue()
-        throws InvalidEntryInternalException, JsonProcessingException {
+        throws InvalidEntryInternalException, IOException {
         UserDto sampleUser = createUserWithRolesAndInstitution();
         ObjectNode json = objectMapper.convertValue(sampleUser, ObjectNode.class);
         assertThatSerializedItemContainsType(json, USER_TYPE_LITERAL);
@@ -212,7 +212,7 @@ public class UserDtoTest extends DtoTest {
             .build();
     }
 
-    private List<RoleDto> duplicateRoles(UserDto user) throws InvalidEntryInternalException {
+    private List<RoleDto> duplicateRoles(UserDto user) {
         List<RoleDto> duplicateRoles = user.getRoles().stream()
             .map(attempt(r -> r.copy().withName(r.getRoleName() + "_copy").build()))
             .flatMap(Try::stream)

--- a/user-access-service/build.gradle
+++ b/user-access-service/build.gradle
@@ -9,29 +9,23 @@ dependencies {
     implementation(group: 'com.amazonaws', name: 'aws-java-sdk-dynamodb', version: project.ext.awsSdkVersion) {
         because("This module contains the Dynamo access details and will be used by " +
                 "any the handlers")
-    }
 
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk-api-gateway', version: project.ext.awsSdkVersion
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
 
-    implementation(group: 'com.amazonaws', name: 'aws-java-sdk-core', version: project.ext.awsSdkVersion) {
-        because("It is used by our code directly")
-    }
-
-    implementation(group: 'com.amazonaws', name: 'aws-java-sdk-secretsmanager', version: project.ext.awsSdkVersion) {
-        because("we need to read the API key")
-    }
-    implementation(group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.1') {
-        because("It implements lambda handlers")
     }
 
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: '1.8.0-beta4') {
         because "Because we use the library directly to define loggers in our code"
     }
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: project.ext.jacksonVersion
-    implementation(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.ext.jacksonVersion)
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: project.ext.jacksonVersion
-    implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
 
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: project.ext.jacksonVersion
+    implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion
+    runtimeOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: project.ext.jacksonVersion)
 
     testImplementation project(':user-access-testing')
 }

--- a/user-access-testing/build.gradle
+++ b/user-access-testing/build.gradle
@@ -4,7 +4,18 @@ dependencies {
     implementation project(':user-access-service')
     implementation project(':user-access-commons')
 
-    implementation( group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion)
+    compileOnly(group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: project.ext.nvaCommonsVersion) {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-parameter-names'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-sts'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-secretsmanager'
+        exclude group: 'com.amazonaws', module: 'aws-lambda-java-events'
+        exclude group: 'com.amazonaws', module: 'aws-java-sdk-lambda'
+    }
     implementation group: 'com.amazonaws', name: 'DynamoDBLocal', version: '1.12.0'
     implementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     implementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jupiterVersion


### PR DESCRIPTION
AWS complained that the size of the application was too big. I assume it is because of lack of usage of two versions of Jackson libraries. I have tried to eliminate as many dependencies as possible using gradleLint.